### PR TITLE
cli-color missing

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var estar = require('.');
+var estar = require(__dirname);
 
 var jsxPath = __dirname+'/jsx/test.jsx';
 var out = __dirname+'/build.jsx';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "through2": "^0.4.1",
     "byline": "^4.1.1",
     "yargs": "^1.2.1",
+    "cli-color": "^0.3.2",
     "lodash.reduce": "^2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
bin の方だと

```
$ es-tar xxx.jsx
```

で「Error: Cannot find module 'cli-color'」になる
